### PR TITLE
chore: fixed newlines and added content-length

### DIFF
--- a/cosmo/app.py
+++ b/cosmo/app.py
@@ -34,10 +34,10 @@ class App:
         error = self.errors.get(error_code, None)
         if error is None:
             raise ValueError(f"Error code {error_code} not found")
-        base = f"HTTP/1.0 {error_code} {error}\nContent-Type: text/plain\n"
+        base = f"HTTP/1.0 {error_code} {error}\r\nContent-Type: text/plain\r\n"
         for key in self.default_headers.keys():
-            base += f"{key}: {self.default_headers[key]}\n"
-        base += f"\n{error}\n\n"
+            base += f"{key}: {self.default_headers[key]}\r\n"
+        base += f"\r\n{error}\r\n"
         conn.sendall(base.encode())
         return
 

--- a/cosmo/route.py
+++ b/cosmo/route.py
@@ -19,23 +19,24 @@ class Route:
     async def _create_response(self, request: Request):
         try:
             content = await self.function(request)
+            self.headers["Content-Length"] = len(content.content) + 2
             if content.headers is not None:
                 for header in content.headers:
                     self.headers[header] = content.headers[header]
             headers = ""
             for header in self.headers.keys():
-                headers += f"{header}: {self.headers[header]}\n"
-            headers += "\n"
+                headers += f"{header}: {self.headers[header]}\r\n"
+            headers += "\r\n"
             if type(content.content) is bytes:
                 return (
-                    b"HTTP/1.0 200 OK\n"
+                    b"HTTP/1.0 200 OK\r\n"
                     + bytes(headers, encoding="utf-8")
                     + content.content
                 )
             else:
-                return f"HTTP/1.0 200 OK\n{headers}{content.content}".encode()
+                return f"HTTP/1.0 200 OK\r\n{headers}{content.content}\r\n".encode()
         except Exception as e:
             logger.critical(
                 f"Traceback encountered while sending response: {traceback.format_exc(e.__traceback__)}"
             )
-            return "HTTP/1.0 500 Internal Server Error\nContent-Type: text/plain\n\nInternal Server Error"
+            return "HTTP/1.0 500 Internal Server Error\r\nContent-Type: text/plain\r\n\r\nInternal Server Error"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "cosmo"
-version = "0.4.0"
+version = "0.4.1"
 description = "A web server implementation that uses raw sockets."
 authors = ["Kronifer <44979306+Kronifer@users.noreply.github.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
fixed newlines and stopped infinite loading in some clients by adding a content-length header